### PR TITLE
Fix autorequire package names.

### DIFF
--- a/lib/puppet/type/vagrant_box.rb
+++ b/lib/puppet/type/vagrant_box.rb
@@ -33,7 +33,7 @@ Puppet::Type.newtype :vagrant_box do
   end
 
   autorequire :package do
-    %w(Vagrant vagrant)
+    %w(Vagrant_1_3_5 vagrant)
   end
 
   autorequire :vagrant_plugin do

--- a/lib/puppet/type/vagrant_plugin.rb
+++ b/lib/puppet/type/vagrant_plugin.rb
@@ -25,7 +25,7 @@ Puppet::Type.newtype(:vagrant_plugin) do
   end
 
   autorequire :package do
-    %w(Vagrant vagrant)
+    %w(Vagrant_1_3_5 vagrant)
   end
 
   autorequire :file do


### PR DESCRIPTION
The name of the main package was changed in
4c24def2aa637f889ad2b376741a83a65ddf115d however this was not
changed in the autorequire.  The result is boxen will attempt to
install plugins before the main package.

Note, this should be put into a variable however I could not see
how to do that.
