### PR TITLE
Bump vagrant version to 1.4.0

### DIFF
--- a/lib/puppet/type/vagrant_box.rb
+++ b/lib/puppet/type/vagrant_box.rb
@@ -33,7 +33,7 @@ Puppet::Type.newtype :vagrant_box do
   end
 
   autorequire :package do
-    %w(Vagrant_1_3_5 vagrant)
+    %w(Vagrant_1_4_0 vagrant)
   end
 
   autorequire :vagrant_plugin do

--- a/lib/puppet/type/vagrant_plugin.rb
+++ b/lib/puppet/type/vagrant_plugin.rb
@@ -25,7 +25,7 @@ Puppet::Type.newtype(:vagrant_plugin) do
   end
 
   autorequire :package do
-    %w(Vagrant_1_3_5 vagrant)
+    %w(Vagrant_1_4_0 vagrant)
   end
 
   autorequire :file do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,13 +1,13 @@
-# Public: Installs Vagrant 1.3.5
+# Public: Installs Vagrant 1.4.0
 #
 # Usage:
 #
 #   include vagrant
 
 class vagrant {
-  package { 'Vagrant_1_3_5':
+  package { 'Vagrant_1_4_0':
     ensure   => installed,
-    source   => 'http://files.vagrantup.com/packages/a40522f5fabccb9ddabad03d836e120ff5d14093/Vagrant-1.3.5.dmg',
+    source   => 'https://dl.bintray.com/mitchellh/vagrant/Vagrant-1.4.0.dmg',
     provider => 'pkgdmg'
   }
 

--- a/spec/classes/vagrant_spec.rb
+++ b/spec/classes/vagrant_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'vagrant' do
   it do
-    should contain_package('Vagrant_1_3_5').with({
+    should contain_package('Vagrant_1_4_0').with({
       :ensure   => 'installed',
       :provider => 'pkgdmg'
     })


### PR DESCRIPTION
Simply a find and replace on the version number + the new download URL from bintray.
