### PR TITLE
enable installation of bash completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 /.bundle
+/.rake_t_cache
 /.ruby-version
 /spec/fixtures/.librarian
 /spec/fixtures/.tmp
 /spec/fixtures/Puppetfile.lock
-/spec/fixtures/modules/boxen/
+/spec/fixtures/modules/*
 /spec/fixtures/vendor

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Install [Vagrant](http://www.vagrantup.com/) on your Mac.
 ## Usage
 
 ```puppet
-include vagrant
+class { 'vagrant': }
 ```
 By default, the module will install Vagrant 1.6.3. You can specify a different version of Vagrant to install (minimum version is 1.4.0 due to download locations). To install Vagrant 1.4.0, you would specify the version as follows:
 
 ```puppet
 class { 'vagrant':
-  version => '1.6.3'
+  version => '1.4.0'
 }
 ```
 
@@ -40,6 +40,39 @@ vagrant::box { 'squeeze64/vmware_fusion':
 }
 ```
 
+Bash Completion
+--
+
+[Bash](https://www.gnu.org/software/bash/) supports tab-completion for commands, _i.e._ you can type part of a command, then press Tab, and Bash will attempt to determine what command you have begun typing and then complete the command for you.  By default, Bash can only complete commands by searching `$PATH`; to enable completion for commands that have subcommands (like `vagrant`), you need to add additional Bash configuration.
+
+To install this configuration automatically, invoke this class as follows:
+
+```puppet
+class { 'vagrant':
+  completion => true,
+}
+```
+
+This will install a [Homebrew](http://brew.sh/) package that provides the necessary configuration.  Once you have done so, **RESTART YOUR SHELL**, and then you'll be able to do something like the following:
+
+```console
+$ vagrant <TAB><TAB>
+box            docker-run     init           plugin         resume         ssh            up
+connect        global-status  list-commands  provision      rsync          ssh-config     version
+destroy        halt           login          rdp            rsync-auto     status
+docker-logs    help           package        reload         share          suspend
+$ vagrant bo<TAB>
+$ vagrant box <TAB><TAB>
+add        help       list       remove     repackage
+$ vagrant box li<TAB>
+$ vagrant box list <RETURN>
+puppetlabs/centos-6.5-64-puppet (vmware_desktop, 0.2.0)
+$
+```
+
 ## Required Puppet Modules
 
 * `boxen`
+* `homebrew`
+* `repository`
+* `stdlib`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,17 @@
 #
 #   include vagrant
 
-class vagrant($version = '1.6.3') {
+class vagrant(
+  $version = '1.6.3',
+  $completion = false
+) {
+  validate_bool($completion)
+
+  $ensure_pkg = $completion ? {
+    true    => 'present',
+    default => 'absent',
+  }
+
   package { "Vagrant_${version}":
     ensure   => installed,
     source   => "https://dl.bintray.com/mitchellh/vagrant/vagrant_${version}.dmg",
@@ -12,6 +22,15 @@ class vagrant($version = '1.6.3') {
   }
 
   file { "/Users/${::boxen_user}/.vagrant.d":
-    ensure => directory
+    ensure  => directory,
+    require => Package["Vagrant_${version}"],
+  }
+
+  homebrew::tap { 'homebrew/completions': }
+
+  package { 'vagrant-completion':
+    ensure   => $ensure_pkg,
+    provider => 'homebrew',
+    require  => Homebrew::Tab['homebrew/completions'],
   }
 }

--- a/spec/classes/vagrant_spec.rb
+++ b/spec/classes/vagrant_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe 'vagrant' do
+  let (:facts) { default_test_facts }
+
   describe 'when not specifiying a version' do
     it { should contain_package('Vagrant_1.6.3').with({
       :ensure   => 'installed',
@@ -13,6 +15,14 @@ describe 'vagrant' do
 
     it { should contain_package('Vagrant_1.5.0')}
     it { should contain_package('Vagrant_1.5.0').with_source('https://dl.bintray.com/mitchellh/vagrant/vagrant_1.5.0.dmg')}
+  end
+
+  describe 'when installing bash completion' do
+    let (:params) {{:completion => true}}
+
+    it { should contain_package('Vagrant_1.6.3')}
+    it { should contain_package('Vagrant_1.6.3').with_source('https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.3.dmg')}
+    it { should contain_package('vagrant-completion').with_provider('homebrew')}
   end
 
 end

--- a/spec/fixtures/Puppetfile
+++ b/spec/fixtures/Puppetfile
@@ -1,1 +1,4 @@
-mod 'boxen', '3.6.0', :github_tarball => 'boxen/puppet-boxen'
+mod 'boxen', '3.3.3', :github_tarball => 'boxen/puppet-boxen'
+mod 'homebrew', '1.9.3', :github_tarball => 'boxen/puppet-homebrew'
+mod 'repository', '2.3.0', :github_tarball => 'boxen/puppet-repository'
+mod 'stdlib', '4.1.0', :github_tarball => 'puppetlabs/puppetlabs-stdlib'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,9 @@ end
 
 def default_test_facts
   {
-    :boxen_user => "testuser",
-    :boxen_home => "/test/boxen"
+    :boxen_user    => "testuser",
+    :boxen_home    => "/test/boxen",
+    :boxen_repodir => "/test/boxen/our-boxen",
+    :boxen_srcdir  => "/test/boxen/src",
   }
 end


### PR DESCRIPTION
No change from default behavior, but optionally install vagrant-completion
homebrew package.
