### PR TITLE
use vagrant box list rather than file structure.

### DIFF
--- a/lib/puppet/provider/vagrant_box/vagrant_box.rb
+++ b/lib/puppet/provider/vagrant_box/vagrant_box.rb
@@ -40,8 +40,8 @@ Puppet::Type.type(:vagrant_box).provide :vagrant_box do
     else
       name, vprovider = @resource[:name].split('/')
 
-      File.directory? \
-        "/Users/#{Facter[:boxen_user].value}/.vagrant.d/boxes/#{name}/#{vprovider}"
+      output = `vagrant box list`
+      /#{name}\s+\(#{vprovider}\)/.match(output)
     end
   end
 


### PR DESCRIPTION
Vagrant 1.5 changed file structure to add support for versions so current check fails. This uses vagrant box list to test if the box is already installed.
