### PR TITLE
Fix box detection

### DIFF
--- a/lib/puppet/provider/vagrant_box/vagrant_box.rb
+++ b/lib/puppet/provider/vagrant_box/vagrant_box.rb
@@ -32,8 +32,8 @@ Puppet::Type.type(:vagrant_box).provide :vagrant_box do
     else
       name, vprovider = @resource[:name].split('/')
 
-      File.directory? \
-        "/Users/#{Facter[:boxen_user].value}/.vagrant.d/boxes/#{name}/#{vprovider}"
+      boxes = vagrant "box", "list"
+      boxes =~ /^#{name}\s+\(#{vprovider}\)/
     end
   end
 


### PR DESCRIPTION
Vagrant 1.5 added box version support, which changes the directory structure that we were expecting. As slow as it is, we should use vagrant's `box list` command to test which boxes are installed, rather than depending on knowledge of its private directory structure.

Replaces #42, and fixes #36 
