### PR TITLE
Fix box list regex

### DIFF
--- a/lib/puppet/provider/vagrant_box/vagrant_box.rb
+++ b/lib/puppet/provider/vagrant_box/vagrant_box.rb
@@ -33,7 +33,7 @@ Puppet::Type.type(:vagrant_box).provide :vagrant_box do
       name, vprovider = @resource[:name].split('/')
 
       boxes = vagrant "box", "list"
-      boxes =~ /^#{name}\s+\(#{vprovider}\)/
+      boxes =~ /^#{name}\s+\(#{vprovider}(, .+)?\)/
     end
   end
 


### PR DESCRIPTION
I didn't anticipate vagrant 1.6's changes to `vagrant box list` output in the previous PR #45; this fixes that issue.
