### PR TITLE
Allow provider to work beyond MacOS.

### DIFF
--- a/lib/puppet/provider/vagrant.rb
+++ b/lib/puppet/provider/vagrant.rb
@@ -1,0 +1,32 @@
+require 'etc'
+require 'puppet/util/execution'
+
+class Puppet::Provider::Vagrant <  Puppet::Provider
+  include Puppet::Util::Execution
+
+  private
+  def home_dir
+    Etc.getpwnam(@resource[:user]).dir
+  end
+
+  def custom_environment
+    {
+      "HOME"         => home_dir,
+      "VAGRANT_HOME" => "#{home_dir}/.vagrant.d",
+    }
+  end
+
+  def opts
+    {
+      :combine            => true,
+      :custom_environment => custom_environment,
+      :failonfail         => true,
+      :uid                => @resource[:user],
+    }
+  end
+
+  def vagrant(*args)
+    cmd = ["/usr/bin/vagrant"] + args
+    execute cmd, opts
+  end
+end

--- a/lib/puppet/provider/vagrant_box/vagrant_box.rb
+++ b/lib/puppet/provider/vagrant_box/vagrant_box.rb
@@ -1,7 +1,6 @@
-require 'puppet/util/execution'
+require 'puppet/provider/vagrant'
 
-Puppet::Type.type(:vagrant_box).provide :vagrant_box do
-  include Puppet::Util::Execution
+Puppet::Type.type(:vagrant_box).provide(:vagrant_box, :parent => Puppet::Provider::Vagrant) do
 
   def create
     name, vprovider = @resource[:name].split('/')
@@ -22,7 +21,6 @@ Puppet::Type.type(:vagrant_box).provide :vagrant_box do
 
   def destroy
     name, vprovider = @resource[:name].split('/')
-
     vagrant "box", "remove", name, "--provider", vprovider
   end
 
@@ -35,27 +33,5 @@ Puppet::Type.type(:vagrant_box).provide :vagrant_box do
       boxes = vagrant "box", "list"
       boxes =~ /^#{name}\s+\(#{vprovider}(, .+)?\)/
     end
-  end
-
-  private
-  def custom_environment
-    {
-      "HOME"         => "/Users/#{Facter[:boxen_user].value}",
-      "VAGRANT_HOME" => "/Users/#{Facter[:boxen_user].value}/.vagrant.d",
-    }
-  end
-
-  def opts
-    {
-      :combine            => true,
-      :custom_environment => custom_environment,
-      :failonfail         => true,
-      :uid                => Facter[:boxen_user].value,
-    }
-  end
-
-  def vagrant(*args)
-    cmd = ["/usr/bin/vagrant"] + args
-    execute cmd, opts
   end
 end

--- a/lib/puppet/type/vagrant_box.rb
+++ b/lib/puppet/type/vagrant_box.rb
@@ -18,6 +18,10 @@ Puppet::Type.newtype :vagrant_box do
   newparam :source do
   end
 
+  newparam :user do
+    defaultto(Facter.value(:boxen_user) || 'root')
+  end
+
   newparam :force do
     validate do |value|
       unless value.is_a? Boolean
@@ -27,7 +31,9 @@ Puppet::Type.newtype :vagrant_box do
   end
 
   autorequire :package do
-    %w(Vagrant_1_4_2 vagrant)
+    catalog.resources.
+      find_all{|s| s.type == :package and s[:name] =~ /^[Vv]agrant/ }.
+      collect{|s| s[:name]}
   end
 
   autorequire :vagrant_plugin do

--- a/lib/puppet/type/vagrant_plugin.rb
+++ b/lib/puppet/type/vagrant_plugin.rb
@@ -1,3 +1,5 @@
+require 'etc'
+
 Puppet::Type.newtype(:vagrant_plugin) do
   ensurable do
     newvalue :present do
@@ -24,15 +26,19 @@ Puppet::Type.newtype(:vagrant_plugin) do
     end
   end
 
+  newparam :user do
+    defaultto(Facter.value(:boxen_user) || 'root')
+  end
+
   newparam :version
 
   autorequire :package do
-    %w(Vagrant_1_4_2 vagrant)
+    catalog.resources.
+      find_all{|s| s.type == :package and s[:name] =~ /^[Vv]agrant/ }.
+      collect{|s| s[:name]}
   end
 
   autorequire :file do
-    %W(
-    /Users/#{Facter[:boxen_user].value}/.vagrant.d/license-#{self[:name]}.lic
-    )
+    %W(#{Etc.getpwnam(self[:user]).dir}/.vagrant.d/license-#{self[:name]}.lic)
   end
 end


### PR DESCRIPTION
- Add parent provider and migrate shared methods.
- Add detection for MacOS specific path.
- Maintain boxen as default user, but support other target user.
- Fix autorequire so works with all vagrant versions.
