### PR TITLE
Make prefixing of plugin names optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ vagrant::plugin { 'vagrant-berkshelf':
 }
 ```
 
+By default, the module will prefix any plugin name that is missing the `vagrant-` prefix. e.g:
+
+```puppet
+vagrant::plugin { 'berkshelf': } # Resolves to vagrant-berkshelf
+```
+
+Some plugins such as [sahara](https://github.com/jedi4ever/sahara) do not use this prefix. You can override the automatic prefix behaviour with the prefix parameter. The usage would look as follows:
+
+```puppet
+vagrant::plugin { 'sahara':
+  prefix => false
+}
+```
+
 Boxes
 --
 

--- a/lib/puppet/type/vagrant_plugin.rb
+++ b/lib/puppet/type/vagrant_plugin.rb
@@ -18,12 +18,6 @@ Puppet::Type.newtype(:vagrant_plugin) do
 
   newparam :name do
     isnamevar
-
-    validate do |value|
-      unless value =~ /\Avagrant-\w+(-\w+)*\z/
-        raise Puppet::Error, "Invalid value for name: #{value}"
-      end
-    end
   end
 
   newparam :user do

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -10,11 +10,12 @@ define vagrant::plugin(
   $ensure  = 'present',
   $force   = false,
   $license = undef,
-  $version = latest
+  $version = latest,
+  $prefix  = true
 ) {
   require vagrant
 
-  if $name =~ /^vagrant-/ {
+  if !$prefix or $name =~ /^vagrant-/ {
     $plugin_name = $name
   } else {
     $plugin_name = "vagrant-${name}"

--- a/spec/defines/vagrant__plugin_spec.rb
+++ b/spec/defines/vagrant__plugin_spec.rb
@@ -17,6 +17,18 @@ describe 'vagrant::plugin' do
     it do
       should contain_vagrant_plugin('vagrant-vmware-fusion')
     end
+
+    context 'prefix is false' do
+      let(:params) do
+        {
+          :prefix => false
+        }
+      end
+
+      it do
+        should contain_vagrant_plugin('vmware-fusion')
+      end
+    end
   end
 
   context 'version specified' do


### PR DESCRIPTION
This pull request adds a `prefix` param to `vagrant::plugin` which will default to false, but allows the installation of plugins that do not use the `vagrant-` prefix.

This problem was originally reported in #52, and the comment was made by @dgoodlad that he would "happily accept a pull request which changed that behavior if it works with vagrant's expectations" - to be honest it's not clear what the vagrant projects expectations are. Most plugins are prefixed with `vagrant-` but not all of them are, so this change enables those plugins to be installed. Vagrant's [own plugin documentation](https://docs.vagrantup.com/v2/plugins/packaging.html) has an example plugin named `my-vagrant-plugin` and doesn't appear to make any explicit statement suggesting that all plugins must begin with the `vagrant-` prefix.