### PR TITLE
Only tap homebrew/completions when $completion parameter is set to true

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@ class vagrant(
 ) {
   validate_bool($completion)
 
-  $ensure_pkg = $completion ? {
+  $ensure_completion = $completion ? {
     true    => 'present',
     default => 'absent',
   }
@@ -26,10 +26,12 @@ class vagrant(
     require => Package["Vagrant_${version}"],
   }
 
-  homebrew::tap { 'homebrew/completions': }
+  homebrew::tap { 'homebrew/completions':
+    ensure => $ensure_completion,
+  }
 
   package { 'vagrant-completion':
-    ensure   => $ensure_pkg,
+    ensure   => $ensure_completion,
     provider => 'homebrew',
     require  => Homebrew::Tap['homebrew/completions'],
   }


### PR DESCRIPTION
When we `include vagrant`, `$completion` will default to false and the
`vagrant-completion` package will not be installed.  `homebrew/completions` will
be taped nonetheless, however. This is not necessary. Change the manifest to
only tap `homebrew-versions` if `$completion` is true.