### PR TITLE
Fixing downloads of Vagrant > 1.9.2

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,9 +15,15 @@ class vagrant(
     default => 'absent',
   }
 
+  if $version > '1.9.2' {
+    $source = "https://releases.hashicorp.com/vagrant/${version}/vagrant_${version}_x86_64.dmg"
+  } else {
+    $source = "https://releases.hashicorp.com/vagrant/${version}/vagrant_${version}.dmg"
+  }
+
   package { "Vagrant_${version}":
     ensure   => installed,
-    source   => "https://releases.hashicorp.com/vagrant/${version}/vagrant_${version}.dmg",
+    source   => $source,
     provider => 'pkgdmg'
   }
 


### PR DESCRIPTION
Addresses #69 

Has been tested against Vagrant 1.9.4 and 1.9.2